### PR TITLE
Improve type isolation

### DIFF
--- a/.yarn/versions/d8b998e8.yml
+++ b/.yarn/versions/d8b998e8.yml
@@ -1,0 +1,2 @@
+releases:
+  ts-auto-mock-env: minor

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "dist"
   ],
   "scripts": {
-    "test": "yarn ts-node --transpile-only ./scripts/generate-mocks.ts test/mocks/tsconfig.json && grep 'globalFunction' test/mocks/index.js >/dev/null",
+    "test": "yarn ts-node --transpile-only ./scripts/generate-mocks.ts test/mocks/tsconfig.json && grep 'importGlobalFunction' test/mocks/index.js >/dev/null && grep 'referenceGlobalFunction' test/mocks/index.js >/dev/null",
     "build": "tsc --outDir dist",
     "prepack": "yarn build"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ts-auto-mock-env",
-  "version": "1.0.1-2",
+  "version": "1.0.2",
   "author": "martinjlowm <martin@martinjlowm.dk>",
   "license": "MIT",
   "repository": {

--- a/test/declarations/global.d.ts
+++ b/test/declarations/global.d.ts
@@ -1,1 +1,0 @@
-declare function globalFunction(): void;

--- a/test/declarations/import.d.ts
+++ b/test/declarations/import.d.ts
@@ -1,0 +1,1 @@
+declare function importGlobalFunction(): void;

--- a/test/declarations/index.d.ts
+++ b/test/declarations/index.d.ts
@@ -1,0 +1,3 @@
+/// <reference path='./reference.d.ts' />
+
+import './import';

--- a/test/declarations/reference.d.ts
+++ b/test/declarations/reference.d.ts
@@ -1,0 +1,1 @@
+declare function referenceGlobalFunction(): void;

--- a/test/mocks/tsconfig.json
+++ b/test/mocks/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "noEmit": false,
-    "types": ["../declarations/global"]
+    "types": ["../declarations"]
   },
   "include": ["./*"]
 }


### PR DESCRIPTION
Types are now filtered based on `hasNoDefaultLib` which appears to exclude automatically imported library declarations, thus isolates the specified types in the config.